### PR TITLE
default namespace is different from the namespace of the traits and v…

### DIFF
--- a/musabase/cgiar_banana_ontology.obo
+++ b/musabase/cgiar_banana_ontology.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 auto-generated-by: java
-default-namespace: BananaTrait
+default-namespace: banana_trait_ontology
 namespace-id-rule: * CO_325:$sequence(7,0000000,0009999)$
 ontology: CO_325
 


### PR DESCRIPTION
…ariables

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

default-namespace header should be different from the namespace of the traits and variables 
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [ ] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [ ] New variables have a parent trait ID 
    - [ ] New variables have methods and scales 
  - [ ] The OBO file has been validated
    - [ ] checked in musabase
    - [ ] checked CropOntology
